### PR TITLE
feat(abc:simple-table): add a new boolea attribute named `oneBaseInde…

### DIFF
--- a/packages/abc/simple-table/index.md
+++ b/packages/abc/simple-table/index.md
@@ -19,7 +19,7 @@ config: AdSimpleTableConfig
 - 通过 `extraParams`、`reqMethod` 等参数解决请求数据格式问题
 - 通过 `resReName` 重置数据 `key` 而无须担心后端数据格式是否满足 `simpel-table` 需求
 - 通过 `preDataChange` 可以对表格渲染前对数据进一步优化
-- 通过 `oneBaseIndexed` 可以调整 http 请求时 `pi` 参数是否遵循 1 基索引，默认情况下为 1 基索引，否则为 0 基索引
+- 通过 `zeroIndexedOnPage` 可以调整 http 请求时 `pi` 参数是否遵循 0 基索引，默认情况下为 1 基索引
 
 ### 静态数据
 
@@ -48,7 +48,7 @@ config: AdSimpleTableConfig
 `[preDataChange]` | 数据处理前回调，一般在使用 `url` 时很有用 | `(data: SimpleTableData[]) => SimpleTableData[]` | -
 `[pi]` | 当前页码 | `number` | `10`
 `[ps]` | 每页数量，当设置为 `0` 表示不分页，默认：`10` | `number` | `10`
-`[oneBaseIndexed]` | 后端分页是否采用`1`基索引，只在`data`类型为`string`时有效 | `boolean` | `true`
+`[zeroIndexedOnPage]` | 后端分页是否采用`0`基索引，只在`data`类型为`string`时有效 | `boolean` | `false`
 `[frontPagination]` | 前端分页，当 `data` 为 `any[]` 或 `Observable<any[]>` 有效 | `boolean` | `true`
 `[showPagination]` | 是否显示分页器；当未指定时若 `ps>total` 情况下自动不显示 | `boolean` | -
 `[pagePlacement]` | 分页方向 | `left,center,right` | `right`

--- a/packages/abc/simple-table/index.md
+++ b/packages/abc/simple-table/index.md
@@ -19,6 +19,7 @@ config: AdSimpleTableConfig
 - 通过 `extraParams`、`reqMethod` 等参数解决请求数据格式问题
 - 通过 `resReName` 重置数据 `key` 而无须担心后端数据格式是否满足 `simpel-table` 需求
 - 通过 `preDataChange` 可以对表格渲染前对数据进一步优化
+- 通过 `oneBaseIndexed` 可以调整 http 请求时 `pi` 参数是否遵循 1 基索引，默认情况下为 1 基索引，否则为 0 基索引
 
 ### 静态数据
 
@@ -47,6 +48,7 @@ config: AdSimpleTableConfig
 `[preDataChange]` | 数据处理前回调，一般在使用 `url` 时很有用 | `(data: SimpleTableData[]) => SimpleTableData[]` | -
 `[pi]` | 当前页码 | `number` | `10`
 `[ps]` | 每页数量，当设置为 `0` 表示不分页，默认：`10` | `number` | `10`
+`[oneBaseIndexed]` | 后端分页是否采用`1`基索引，只在`data`类型为`string`时有效 | `boolean` | `true`
 `[frontPagination]` | 前端分页，当 `data` 为 `any[]` 或 `Observable<any[]>` 有效 | `boolean` | `true`
 `[showPagination]` | 是否显示分页器；当未指定时若 `ps>total` 情况下自动不显示 | `boolean` | -
 `[pagePlacement]` | 分页方向 | `left,center,right` | `right`

--- a/packages/abc/simple-table/simple-table.component.ts
+++ b/packages/abc/simple-table/simple-table.component.ts
@@ -330,13 +330,13 @@ export class SimpleTableComponent implements OnInit, OnChanges, OnDestroy {
   >();
   /** 后端分页是否采用`1`基索引，只在`data`类型为`string`时有效 */
   @Input()
-  get oneBaseIndexed() {
-    return this._oneBaseIndexed;
+  get zeroIndexedOnPage() {
+    return this._zeroIndexedOnPage;
   }
-  set oneBaseIndexed(value: any) {
-    this._oneBaseIndexed = toBoolean(value);
+  set zeroIndexedOnPage(value: any) {
+    this._zeroIndexedOnPage = toBoolean(value);
   }
-  private _oneBaseIndexed = true;
+  private _zeroIndexedOnPage = false;
 
   // endregion
 
@@ -397,7 +397,7 @@ export class SimpleTableComponent implements OnInit, OnChanges, OnDestroy {
   private getAjaxData(url?: string): Observable<any> {
     const params: any = Object.assign(
       {
-        [this.reqReName.pi]: this._oneBaseIndexed ? this.pi : this.pi - 1,
+        [this.reqReName.pi]: this._zeroIndexedOnPage ? this.pi - 1 : this.pi,
         [this.reqReName.ps]: this.ps,
       },
       this.extraParams,

--- a/packages/abc/simple-table/simple-table.component.ts
+++ b/packages/abc/simple-table/simple-table.component.ts
@@ -328,6 +328,15 @@ export class SimpleTableComponent implements OnInit, OnChanges, OnDestroy {
   readonly filterChange: EventEmitter<SimpleTableColumn> = new EventEmitter<
     SimpleTableColumn
   >();
+  /** 后端分页是否采用`1`基索引，只在`data`类型为`string`时有效 */
+  @Input()
+  get oneBaseIndexed() {
+    return this._oneBaseIndexed;
+  }
+  set oneBaseIndexed(value: any) {
+    this._oneBaseIndexed = toBoolean(value);
+  }
+  private _oneBaseIndexed = true;
 
   // endregion
 
@@ -388,7 +397,7 @@ export class SimpleTableComponent implements OnInit, OnChanges, OnDestroy {
   private getAjaxData(url?: string): Observable<any> {
     const params: any = Object.assign(
       {
-        [this.reqReName.pi]: this.pi,
+        [this.reqReName.pi]: this._oneBaseIndexed ? this.pi : this.pi - 1,
         [this.reqReName.ps]: this.ps,
       },
       this.extraParams,

--- a/packages/abc/simple-table/simple-table.config.ts
+++ b/packages/abc/simple-table/simple-table.config.ts
@@ -60,6 +60,10 @@ export class AdSimpleTableConfig {
    */
   reqReName?: Object;
   /**
+   * 请求参数 `pi` 是否采用 0 基索引
+   */
+  zeroIndexedOnPage?: boolean;
+  /**
    * 重命名返回参数 `total`、`list`，例如：`{ total: 'Total' }` Total 会被当作 `total`
    */
   resReName?: { total?: string | string[]; list?: string | string[] };

--- a/packages/abc/simple-table/simple-table.spec.ts
+++ b/packages/abc/simple-table/simple-table.spec.ts
@@ -931,6 +931,13 @@ describe('abc: simple-table', () => {
           expect(h.request.params.has('pi')).toBe(false);
           expect(h.request.params.has('pageindex')).toBe(true);
         });
+        it('should be change paramenter pi to pi-1', () => {
+          context.zeroIndexedOnPage = true;
+          context.pi = 1;
+          fixture.detectChanges();
+          const h = httpMock.expectOne(w => true) as TestRequest;
+          expect(h.request.params.get('pi')).toBe((context.pi - 1).toString());
+        });
         it('should be empty array when invalid list', () => {
           fixture.detectChanges();
           httpMock.expectOne(w => true).flush({ list: 'aa' });
@@ -1805,6 +1812,7 @@ describe('abc: simple-table', () => {
         [data]="data" [extraParams]="extraParams"
         [reqMethod]="reqMethod" [reqBody]="reqBody" [reqHeaders]="reqHeaders" [reqReName]="reqReName" (reqError)="reqError()"
         [resReName]="resReName"
+        [zeroIndexedOnPage]="zeroIndexedOnPage"
         [columns]="columns"
         [ps]="ps" [pi]="pi" [total]="total"
         [showPagination]="showPagination"
@@ -1837,6 +1845,7 @@ class TestComponent {
   reqBody: any;
   reqHeaders: any;
   reqReName: Object;
+  zeroIndexedOnPage = false;
   reqError() {}
   resReName: ResReNameType;
   ps = PS;

--- a/packages/abc/simple-table/simple-table.spec.ts
+++ b/packages/abc/simple-table/simple-table.spec.ts
@@ -936,7 +936,7 @@ describe('abc: simple-table', () => {
           context.pi = 1;
           fixture.detectChanges();
           const h = httpMock.expectOne(w => true) as TestRequest;
-          expect(h.request.params.get('pi')).toBe((context.pi - 1).toString());
+          expect(h.request.params.get('pi').toString()).toBe((context.pi - 1).toString());
         });
         it('should be empty array when invalid list', () => {
           fixture.detectChanges();

--- a/packages/abc/simple-table/simple-table.spec.ts
+++ b/packages/abc/simple-table/simple-table.spec.ts
@@ -936,6 +936,7 @@ describe('abc: simple-table', () => {
           context.pi = 1;
           fixture.detectChanges();
           const h = httpMock.expectOne(w => true) as TestRequest;
+          expect(context.comp.zeroIndexedOnPage).toBe(true);
           expect(h.request.params.get('pi').toString()).toBe((context.pi - 1).toString());
         });
         it('should be empty array when invalid list', () => {


### PR DESCRIPTION
…xed`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/cipchk/delon/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Application (the showcase website) / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
当 `data` 为 `url` 时，组件只支持 1 基索引的页码请求，但如果遇到服务器无法与其配合的情况时，此功能将无法使用。

例如 spring data rest 是目前广泛使用的服务端组件，它是强制 0 基索引的，而且无法改变这一行为。这种情况下只能诉求于客户端。

支持这一特性只需要改动很少很少的代码，对当前代码不会造成任何侵入性威胁，不会产生未知BUG。但会让组件实用性大大增加。特别是对于像本人这样使用spring-boot做全栈开发的人来说，这样会大大减少开发时间。

## What is the new behavior?
在 `data` 为 `string` 类型时，添加切换 1/0 基索引的功能。

实现策略较为简单：
添加 `boolean` 属性 `oneBaseIndexed`，默认为 `true`，以兼容当前功能。若其被设置为 `false` 则在设置
 http 请求参数时，`pi` 参数将使用 `pi - 1`（不改变 `pi` 值）。

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

相信这个小小的功能是很多人都需要的，如果代码有任何不完善的地方，本人也将尽我所能做好后续维护工作。
因此希望此PR不要被一票否决，恳请合并。

虽然本人前端功力尚浅，也愿意多交流学习，希望有朝一日能为这套组件贡献多一点。